### PR TITLE
sets up request and registration for user

### DIFF
--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+const API_URL = "/api/users"
+
+// Register user
+const register = async (userData) => {
+    const response = await axios.post(API_URL, userData);
+
+    if(response.data) {
+        localStorage.setItem('user', JSON.Stringify(response.data));
+    }
+
+    return response.data;
+}
+
+const authService = {
+    register,
+}
+
+export default authService;

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -1,4 +1,5 @@
 import {createSlice, createAsyncThunk} from '@reduxjs/toolkit';
+import authService from './authService';
 
 const initialState = {
     user: null,
@@ -12,7 +13,11 @@ const initialState = {
 export const register = createAsyncThunk(
     'auth/register', 
     async (user, thunkAPI) => {  
-        console.log(user);
+        try {
+            return await authService.register(user);
+        } catch (error) {
+            const message = (message.response && message.response.data && message.response.data.message) || error.message || error.toString();
+        }
     }
 );
 


### PR DESCRIPTION
In the `features/auth/authSlice.js` file, the `console.log` is replaced with a "try catch" block. In the `try` is a `return` with `await authService.register(user)`. Then the `catch` has a parameter of `error`, and contains a `message` variable. This variable checks for multiple message scenarios. These are `(message.response && message.response.data && message.response.data.message) || error.message || error.toString();` At the top, `authService` is imported from `./authService`.

In the `features/auth/authService.js` file, `axios` is imported at the top from `axios`. A variable names `API_URL` is added, that is set to "/api/users". Then a `register` variable is set be `async`. This takes a parameter of `userData` for the function. In this function, a `response` variable is set to `await` for `axios.post(API_URL, userData)`. Then an `if` statement is added that takes a parameter of `response.data`. In this conditional, the `localStorage` is set to `setItem('user', JSON.Stringify(response.data))`. The `register` function then returns a `response.data`. Outside of this function, a variable `authService`, is set to contain an object with one item, `register`. Finally, the `export` at the bottom is set to `default authService`.