### PR TITLE
sets up a reset after register

### DIFF
--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -32,7 +32,14 @@ export const login = createAsyncThunk(
 export const authSlice = createSlice({
     name: 'auth',
     initialState,
-    reducers: {},
+    reducers: {
+        reset: (state) => {
+            state.isLoading = false
+            state.isError = false
+            state.isSuccess = false
+            state.message = ''
+        },
+    },
     extraReducers: (builder) => {
         builder
             .addCase(register.pending, (state) => {
@@ -53,4 +60,5 @@ export const authSlice = createSlice({
     }
 })
 
+export const {reset} = authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,8 +1,9 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
+import {useNavigate} from 'react-router-dom';
 import {toast} from 'react-toastify';
 import {FaUser} from 'react-icons/fa';
 import {useSelector, useDispatch} from 'react-redux';
-import {register} from '../features/auth/authSlice';
+import {register, reset} from '../features/auth/authSlice';
 
 function Register() {
     const [formData, setFormData] = useState({
@@ -15,8 +16,22 @@ function Register() {
     const {name, email, password, password2} = formData;
 
     const dispatch = useDispatch();
+    const navigate = useNavigate();
     
-    const {user, isLoading, isSuccess, message} = useSelector((state) => state.auth);
+    const {user, isLoading, isError, isSuccess, message} = useSelector((state) => state.auth);
+
+    useEffect(() => {
+        if(isError) {
+            toast.message(message);
+        }
+
+        // Redirect when logged in
+        if(isSuccess && user) {
+            navigate('/')
+        }
+
+        dispatch(reset());
+    }, [isError, isSuccess, user, message, navigate, dispatch]);
 
     const onChange = (e) => {
         setFormData((prevState) => ({


### PR DESCRIPTION
In the `features/auth/authSlice.js` file, items are added to the `authSlice` function's `reducers`. A `reset` takes in the parameter of `state`. This function then sets `state.isLoading = false`, `state.isError = false`, `state.isSuccess = false`, and `state.message = ''`. 

In the `page/Register.jsx` file, `useEffect` is imported at the top from `react`. This is used further down in the code. A function is passed into it. In this function, an `if` statement checks for `isError`, then uses `toast.message(message)`. Another `if` statement checks for `isSuccess` and `user`, then redirects using `navigate('/')`. To use this, `useNavigate` is imported from `react-router-dom`. The `navigate` is then initialized with `useNavigate()`. To dispatch the reset, the `reset` is imported from `authSlice`. Then back in the `useEffect`, a `dispatch` is used with `reset` passed in. Then several dependencies are added in, which are `[isError, isSuccess, user, message, navigate, dispatch]`. 

In the `features/auth/authSlice.js` file, at the bottom an export is added for the `reset` in the `reducers`, which is `const {reset} = authSlice.actions`.