### PR TITLE
put user in initial state for localstorage

### DIFF
--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -1,8 +1,11 @@
 import {createSlice, createAsyncThunk} from '@reduxjs/toolkit';
 import authService from './authService';
 
+// Get user from localstorage
+const user = JSON.parse(localStorage.getItem('user'));
+
 const initialState = {
-    user: null,
+    user: user ? user : null,
     isError: false,
     isSuccess: false,
     isLoading: false,


### PR DESCRIPTION
In the `features/auth/authSlice.js` file, a comment is added to "Get user from localstorage". A `user` variable is added, which is equal to `JSON.parse(localStorage.getItem('user'))`. Then in the `initialState` object, the `user` is set to `user` if it exists, and `null` if it doesn't.