### PR TITLE
sets up Header.jsx to call logout function

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,20 +1,34 @@
 import {FaSignInAlt, FaSignOutAlt, FaUser} from 'react-icons/fa';
-import {Link} from 'react-router-dom';
+import {Link, useNavigate} from 'react-router-dom';
+import {useSelector, useDispatch} from 'react-redux';
+import {logout, reset} from '../features/auth/authSlice';
 
 function Header() {
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const {user} = useSelector((state) => state.auth);
+
     return (
         <header className="header">
             <div className="logo">
                 <Link to="/">Support Desk</Link>
                 <ul>
-                    <li>
-                        <Link to="login">
-                            <FaSignInAlt />Login
-                        </Link>
-                        <Link to="register">
-                            <FaUser />Register
-                        </Link>
-                    </li>
+                    {user ? (
+                        <button className="btn"><FaSignOutAlt />Logout</button>
+                    ) : (
+                    <>
+                        <li>
+                            <Link to="login">
+                                <FaSignInAlt />Login
+                            </Link>
+                        </li>
+                        <li>
+                            <Link to="register">
+                                <FaUser />Register
+                            </Link>
+                        </li>
+                    </>
+                    )}                    
                 </ul>
             </div>
         </header>

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -20,6 +20,7 @@ export const register = createAsyncThunk(
             return await authService.register(user);
         } catch (error) {
             const message = (message.response && message.response.data && message.response.data.message) || error.message || error.toString();
+            return thunkAPI.rejectWithValue(message);
         }
     }
 );
@@ -33,7 +34,7 @@ export const login = createAsyncThunk(
 );
 
 // Logout user
-export const logout = createAsyncThunk('auth/logout', asynch () => {
+export const logout = createAsyncThunk('auth/logout', async () => {
     await authService.logout();
 })
 


### PR DESCRIPTION
In the `components/Header.jsx` file, several imports are added. The `{Link, useNavigate}` is imported from 'react-router-dom'. The `{useSelector, useDispatch}` is imported from 'react-redux'. The `{logout, reset}` is imported from '../features/auth/authSlice'. Then under the `Header` function, a `navigate` variable is set to `useNavigate()`. Also a `dispatch` variable is set to `useDispatch()`. And a `user` variable is destructured from `useSelector((state) => state.auth)`. In the `return`, a ternary operater for `user` is added in the `<ul>`. The initial condition for `user` is a `<button>` element with the class name of "btn", which contains a font awesome icon of `<FaSignOutAlt />` and a text of "Logout".  Then if the `user` doesn't exist, all of the list items are contained within. Also, a fragment is wrapped around all the `<li>` items.

Also in the `features/auth/authSlice.js` file, a `return thunkAPI.rejectWithValue(message)` is added to the `register` function's try/catch, in the `catch`. Also, in the export for `logout` at the bottom, a syntax correction is made for `async`.