### PR TITLE
adjusts authSlice to register user

### DIFF
--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -4,6 +4,17 @@ const API_URL = "/api/users"
 
 // Register user
 const register = async (userData) => {
+    const response = await axios.post(API_URL + 'login', userData);
+
+    if(response.data) {
+        localStorage.setItem('user', JSON.Stringify(response.data));
+    }
+
+    return response.data;
+}
+
+// Login user
+const login = async (userData) => {
     const response = await axios.post(API_URL, userData);
 
     if(response.data) {
@@ -17,7 +28,8 @@ const register = async (userData) => {
 const logout = () => localStorage.removeItem('user');
 
 const authService = {
-    register,
+    register,    
+    login,
     logout,
 }
 

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -29,7 +29,12 @@ export const register = createAsyncThunk(
 export const login = createAsyncThunk(
     'auth/login', 
     async (user, thunkAPI) => {  
-        console.log(user);
+        try {
+            return await authService.login(user);
+        } catch (error) {
+            const message = (message.response && message.response.data && message.response.data.message) || error.message || error.toString();
+            return thunkAPI.rejectWithValue(message);
+        }
     }
 );
 


### PR DESCRIPTION
In the `authSlice.js` file, in place of the `console.log`, the same `try` `catch` block from the register user is used for the login user. It is updated so the `try` block is set to `authSlice.login`. 

Then in the `authService,js`, the `register` is copied and the function name is updated to `login`. Also the `API_URL` is updated to concatenate "+ `login`". Also, at the bottom of the component, the `AuthService` is updates with `login` as an additional export. 