### PR TITLE
fix: corrected login user post URL

### DIFF
--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -4,7 +4,7 @@ const API_URL = "/api/users"
 
 // Register user
 const register = async (userData) => {
-    const response = await axios.post(API_URL + 'login', userData);
+    const response = await axios.post(API_URL, userData);
 
     if(response.data) {
         localStorage.setItem('user', JSON.Stringify(response.data));
@@ -15,7 +15,7 @@ const register = async (userData) => {
 
 // Login user
 const login = async (userData) => {
-    const response = await axios.post(API_URL, userData);
+    const response = await axios.post(API_URL + 'login', userData);
 
     if(response.data) {
         localStorage.setItem('user', JSON.Stringify(response.data));


### PR DESCRIPTION
In the `auth/authService.js` file, the `response` variable in the `register` function is corrected. The post URL is updated to remove the `login` concatination, to now be `axios.post(API_URL, userData)`. Then in the `login` function for the post URL, the `login` concatination was added to now be `axios.post(API_URL + 'login', userData)`.