### PR TITLE
handles login reducer in authSlice.js

### DIFF
--- a/frontend/src/features/auth/authService.js
+++ b/frontend/src/features/auth/authService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = "/api/users"
+const API_URL = "/api/users/"
 
 // Register user
 const register = async (userData) => {

--- a/frontend/src/features/auth/authSlice.js
+++ b/frontend/src/features/auth/authSlice.js
@@ -71,10 +71,25 @@ export const authSlice = createSlice({
                 state.user =null
 
             })
+            .addCase(login.pending, (state) => {
+                state.isLoading = true
+            })
+            .addCase(login.fulfilled, (state, action) => {
+                state.isLoading = false
+                state.isSuccess = true
+                state.user = action.payload
+            })
+            .addCase(login.rejected, (state, action) => {
+                state.isLoading = false
+                state.isError = true
+                state.message = action.payload
+                state.user =null
+
+            })
             .addCase(logout.fulfilled, (state) => {
                 state.user = null;
             })
-    }
+    },
 })
 
 export const {reset} = authSlice.actions;


### PR DESCRIPTION
In the `features/auth/authSlice.js` file, in the `builder` within the `extraReducers` in the `createSlice` function, 3 more `addCase` functions are added. These are 3 new `addCase` uses for the `Login`, which are duplicated from the 3 `addCase` uses for the `register`. These 3 `addCase` uses are to handle the `pending`, `fulfilled`, and `rejected` states for the `login`.

Also, in the `features/auth/authService.js` file, the url for the `API_URL` variable is given a trailing slash. This makes the url path become `/api/users/`.