### PR TITLE
fixes export to ticketController.js

### DIFF
--- a/backend/controllers/ticketController.js
+++ b/backend/controllers/ticketController.js
@@ -17,7 +17,7 @@ const createTicket = asyncHandler(async (req, res) => {
     res.status(200).json({message: 'createTicket'});
 });
 
-module.exports {
+module.exports = {
     getTickets,
     createTicket,
 }


### PR DESCRIPTION
For the backend, in the `/controller/ticketController.js` file, the `module.exports` at the bottom was given the necessary `=` for the `getTickets` and `createTicket` exports.